### PR TITLE
Fix get_auth_cookie to use correct response field

### DIFF
--- a/pywiglenet.py
+++ b/pywiglenet.py
@@ -70,7 +70,7 @@ class Wigle:
                 allow_redirects=False
             )
             if response.status_code == 302:
-                self.auth_cookie = response.headers['set-cookie'].split(";")[0]
+                self.auth_cookie = response.headers['set-cookie'].split(";")[3].strip()
                 return self.auth_cookie
         except Exception, e:
             print e


### PR DESCRIPTION
The response field being parsed was using the wrong index after splitting on ';', selecting the session number instead of the auth token.
Change tested locally with success.
